### PR TITLE
feat: monitor worldgen stalls and thread usage

### DIFF
--- a/src/main/java/com/thunder/debugguardian/DebugGuardian.java
+++ b/src/main/java/com/thunder/debugguardian/DebugGuardian.java
@@ -4,6 +4,8 @@ import com.thunder.debugguardian.config.DebugConfig;
 import com.thunder.debugguardian.debug.monitor.LiveLogMonitor;
 import com.thunder.debugguardian.debug.Watchdog;
 import com.thunder.debugguardian.debug.monitor.PerformanceMonitor;
+import com.thunder.debugguardian.debug.monitor.ThreadUsageMonitor;
+import com.thunder.debugguardian.debug.monitor.WorldGenFreezeDetector;
 import com.thunder.debugguardian.debug.replay.PostMortemRecorder;
 import com.thunder.debugguardian.util.UnusedConfigScanner;
 import net.minecraft.network.FriendlyByteBuf;
@@ -70,6 +72,8 @@ public class DebugGuardian {
         LiveLogMonitor.start();
         PerformanceMonitor.init();
         PostMortemRecorder.init();
+        WorldGenFreezeDetector.start();
+        ThreadUsageMonitor.start();
 
     }
 

--- a/src/main/java/com/thunder/debugguardian/debug/monitor/ClassLoadingIssueDetector.java
+++ b/src/main/java/com/thunder/debugguardian/debug/monitor/ClassLoadingIssueDetector.java
@@ -10,7 +10,16 @@ public class ClassLoadingIssueDetector {
      */
     public static String identifyCulpritMod(Throwable t) {
         if (t == null) return "Unknown";
-        for (StackTraceElement ste : t.getStackTrace()) {
+        return identifyCulpritMod(t.getStackTrace());
+    }
+
+    /**
+     * Scans the stack trace elements directly and returns the first modId
+     * whose package prefix matches a frame, or "Unknown" if none match.
+     */
+    public static String identifyCulpritMod(StackTraceElement[] stack) {
+        if (stack == null) return "Unknown";
+        for (StackTraceElement ste : stack) {
             String cls = ste.getClassName();
             for (IModInfo mod : ModList.get().getMods()) {
                 if (cls.startsWith(mod.getModId() + ".")) {

--- a/src/main/java/com/thunder/debugguardian/debug/monitor/ThreadUsageMonitor.java
+++ b/src/main/java/com/thunder/debugguardian/debug/monitor/ThreadUsageMonitor.java
@@ -1,0 +1,35 @@
+package com.thunder.debugguardian.debug.monitor;
+
+import com.thunder.debugguardian.DebugGuardian;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Checks thread usage and reports mods that spawn many threads.
+ */
+public class ThreadUsageMonitor {
+    private static final int THREAD_THRESHOLD = 50;
+
+    public static void start() {
+        Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(
+                ThreadUsageMonitor::checkThreads, 10, 10, TimeUnit.SECONDS);
+    }
+
+    private static void checkThreads() {
+        Map<String, Integer> counts = new HashMap<>();
+        Map<Thread, StackTraceElement[]> all = Thread.getAllStackTraces();
+        for (Map.Entry<Thread, StackTraceElement[]> e : all.entrySet()) {
+            String mod = ClassLoadingIssueDetector.identifyCulpritMod(e.getValue());
+            counts.merge(mod, 1, Integer::sum);
+        }
+        for (Map.Entry<String, Integer> e : counts.entrySet()) {
+            if (e.getValue() > THREAD_THRESHOLD && !"Unknown".equals(e.getKey())) {
+                DebugGuardian.LOGGER.warn(
+                        "Mod {} is using {} threads", e.getKey(), e.getValue());
+            }
+        }
+    }
+}

--- a/src/main/java/com/thunder/debugguardian/debug/monitor/WorldGenFreezeDetector.java
+++ b/src/main/java/com/thunder/debugguardian/debug/monitor/WorldGenFreezeDetector.java
@@ -1,0 +1,64 @@
+package com.thunder.debugguardian.debug.monitor;
+
+import com.thunder.debugguardian.DebugGuardian;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Periodically checks the server thread for long-running world generation and
+ * attempts to attribute the work to a mod based on the stack trace.
+ */
+public class WorldGenFreezeDetector {
+    private static final long FREEZE_THRESHOLD_MS = 20_000; // 20 seconds
+    private static long worldGenStart = -1;
+
+    public static void start() {
+        Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(() -> {
+            Thread serverThread = findServerThread();
+            if (serverThread == null) return;
+            StackTraceElement[] stack = serverThread.getStackTrace();
+            boolean inWorldGen = isWorldGenStack(stack);
+            long now = System.currentTimeMillis();
+            if (inWorldGen) {
+                if (worldGenStart < 0) {
+                    worldGenStart = now;
+                } else if (now - worldGenStart > FREEZE_THRESHOLD_MS) {
+                    String culprit = ClassLoadingIssueDetector.identifyCulpritMod(stack);
+                    if (!"Unknown".equals(culprit)) {
+                        DebugGuardian.LOGGER.warn(
+                                "Possible worldgen freeze caused by mod {}", culprit);
+                    } else {
+                        DebugGuardian.LOGGER.warn(
+                                "Possible worldgen freeze detected, culprit unknown");
+                    }
+                    worldGenStart = now; // reset to avoid spamming
+                }
+            } else {
+                worldGenStart = -1;
+            }
+        }, 10, 5, TimeUnit.SECONDS);
+    }
+
+    private static Thread findServerThread() {
+        for (Thread t : Thread.getAllStackTraces().keySet()) {
+            if ("Server thread".equals(t.getName())) {
+                return t;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isWorldGenStack(StackTraceElement[] stack) {
+        if (stack == null) return false;
+        for (StackTraceElement el : stack) {
+            String cls = el.getClassName();
+            if (cls.contains("ChunkStatus") ||
+                    cls.contains("WorldGenRegion") ||
+                    cls.contains("ChunkGenerator")) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- detect long-running world generation and warn which mod may be responsible
- monitor thread counts per mod and log heavy usage
- support stack trace analysis for mod attribution

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68a4d94a20708328b4c9d0b79a185317