### PR TITLE
Add configurable error report interval

### DIFF
--- a/src/main/java/com/thunder/debugguardian/config/DebugConfig.java
+++ b/src/main/java/com/thunder/debugguardian/config/DebugConfig.java
@@ -40,6 +40,11 @@ public class DebugConfig {
             .comment("Enable real-time in-game log monitoring and notifications")
             .define("logging.enableLiveMonitor", true);
 
+    // Error Tracking Settings
+    public static final ModConfigSpec.IntValue LOGGING_ERROR_REPORT_INTERVAL = BUILDER
+            .comment("Number of identical errors to skip before logging again")
+            .defineInRange("logging.errorReportInterval", 100, 1, 10000);
+
     public static final ModConfigSpec SPEC = BUILDER.build();
 
 
@@ -50,6 +55,7 @@ public class DebugConfig {
     public final double performanceMemoryWarningRatio;
     public final boolean compatibilityEnableScan;
     public final boolean loggingEnableLiveMonitor;
+    public final int loggingErrorReportInterval;
 
     private DebugConfig() {
         this.postmortemBufferSize = POSTMORTEM_BUFFER_SIZE.get();
@@ -58,6 +64,7 @@ public class DebugConfig {
         this.performanceMemoryWarningRatio = PERFORMANCE_MEMORY_RATIO.get();
         this.compatibilityEnableScan = COMPAT_ENABLE_SCAN.get();
         this.loggingEnableLiveMonitor = LOGGING_ENABLE_LIVE.get();
+        this.loggingErrorReportInterval = LOGGING_ERROR_REPORT_INTERVAL.get();
     }
 
     public static DebugConfig get() {

--- a/src/main/java/com/thunder/debugguardian/debug/errors/ErrorTracker.java
+++ b/src/main/java/com/thunder/debugguardian/debug/errors/ErrorTracker.java
@@ -1,6 +1,7 @@
 package com.thunder.debugguardian.debug.errors;
 
 import com.thunder.debugguardian.DebugGuardian;
+import com.thunder.debugguardian.config.DebugConfig;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.filter.AbstractFilter;
@@ -10,7 +11,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class ErrorTracker extends AbstractFilter {
     private static final ConcurrentHashMap<String, AtomicInteger> counts = new ConcurrentHashMap<>();
-    private static final int REPORT_INTERVAL = 1;
 
     @Override
     public Filter.Result filter(LogEvent event) {
@@ -18,7 +18,8 @@ public class ErrorTracker extends AbstractFilter {
             String fp = ErrorFingerprinter.fingerprint(event.getThrown());
             AtomicInteger c = counts.computeIfAbsent(fp, k -> new AtomicInteger());
             int count = c.incrementAndGet();
-            if (count % REPORT_INTERVAL == 1) {
+            int interval = DebugConfig.get().loggingErrorReportInterval;
+            if (count % interval == 1) {
                 DebugGuardian.LOGGER.error("[DebugGuardian] Error (" + fp + ") occurred " + count + " time(s)", event.getThrown());
                 return Filter.Result.ACCEPT;
             }


### PR DESCRIPTION
## Summary
- make error tracking report interval configurable via `logging.errorReportInterval`
- use the configured interval to reduce repeated error logs

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68a536cbe5fc83289620c68366606e75