### PR TITLE
Track world-gen stalls and improve crash attribution

### DIFF
--- a/src/main/java/com/thunder/debugguardian/DebugGuardian.java
+++ b/src/main/java/com/thunder/debugguardian/DebugGuardian.java
@@ -6,6 +6,8 @@ import com.thunder.debugguardian.debug.Watchdog;
 import com.thunder.debugguardian.debug.monitor.PerformanceMonitor;
 import com.thunder.debugguardian.debug.monitor.ThreadUsageMonitor;
 import com.thunder.debugguardian.debug.monitor.WorldGenFreezeDetector;
+import com.thunder.debugguardian.debug.monitor.GcPauseMonitor;
+import com.thunder.debugguardian.debug.monitor.StartupFailureReporter;
 import com.thunder.debugguardian.debug.replay.PostMortemRecorder;
 import com.thunder.debugguardian.util.UnusedConfigScanner;
 import net.minecraft.network.FriendlyByteBuf;
@@ -64,6 +66,7 @@ public class DebugGuardian {
         container.registerConfig(ModConfig.Type.COMMON, DebugConfig.SPEC);
 
         Watchdog.start();
+        StartupFailureReporter.install();
 
 
     }
@@ -74,6 +77,7 @@ public class DebugGuardian {
         PostMortemRecorder.init();
         WorldGenFreezeDetector.start();
         ThreadUsageMonitor.start();
+        GcPauseMonitor.start();
 
     }
 

--- a/src/main/java/com/thunder/debugguardian/debug/monitor/ClassLoadingIssueDetector.java
+++ b/src/main/java/com/thunder/debugguardian/debug/monitor/ClassLoadingIssueDetector.java
@@ -3,10 +3,17 @@ package com.thunder.debugguardian.debug.monitor;
 import net.neoforged.fml.ModList;
 import net.neoforged.neoforgespi.language.IModInfo;
 
+import java.nio.file.Path;
+import java.security.CodeSource;
+
+/**
+ * Attempts to identify which mod is responsible for a crash or
+ * class-loading issue by inspecting the stack trace.
+ */
 public class ClassLoadingIssueDetector {
     /**
      * Scans the throwable’s stack trace and returns the first modId
-     * whose package prefix matches a frame, or "Unknown".
+     * whose package or code source matches a frame, or "Unknown".
      */
     public static String identifyCulpritMod(Throwable t) {
         if (t == null) return "Unknown";
@@ -15,18 +22,41 @@ public class ClassLoadingIssueDetector {
 
     /**
      * Scans the stack trace elements directly and returns the first modId
-     * whose package prefix matches a frame, or "Unknown" if none match.
+     * whose package prefix or jar file matches a frame. Falls back to
+     * "Unknown" if none match.
      */
     public static String identifyCulpritMod(StackTraceElement[] stack) {
         if (stack == null) return "Unknown";
         for (StackTraceElement ste : stack) {
             String cls = ste.getClassName();
+            // first try package prefix match
             for (IModInfo mod : ModList.get().getMods()) {
                 if (cls.startsWith(mod.getModId() + ".")) {
                     return mod.getModId();
                 }
             }
+            // fall back to looking up the jar file
+            String modId = findByCodeSource(cls);
+            if (modId != null) {
+                return modId;
+            }
         }
         return "Unknown";
+    }
+
+    private static String findByCodeSource(String clsName) {
+        try {
+            Class<?> cls = Class.forName(clsName);
+            CodeSource src = cls.getProtectionDomain().getCodeSource();
+            if (src == null) return null;
+            Path path = Path.of(src.getLocation().toURI());
+            for (IModInfo mod : ModList.get().getMods()) {
+                if (path.equals(mod.getOwningFile().getFile().getFilePath())) {
+                    return mod.getModId();
+                }
+            }
+        } catch (Exception ignored) {
+        }
+        return null;
     }
 }

--- a/src/main/java/com/thunder/debugguardian/debug/monitor/GcPauseMonitor.java
+++ b/src/main/java/com/thunder/debugguardian/debug/monitor/GcPauseMonitor.java
@@ -1,0 +1,30 @@
+package com.thunder.debugguardian.debug.monitor;
+
+import com.thunder.debugguardian.DebugGuardian;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tracks garbage collection pauses to warn about potential memory leaks
+ * or misbehaving mods causing frequent full GCs.
+ */
+public class GcPauseMonitor {
+    private static final long PAUSE_WARN_MS = 2_000; // 2 seconds
+    private static long lastGcTime = 0;
+
+    public static void start() {
+        Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(() -> {
+            long totalGc = ManagementFactory.getGarbageCollectorMXBeans().stream()
+                    .mapToLong(GarbageCollectorMXBean::getCollectionTime)
+                    .sum();
+            long delta = totalGc - lastGcTime;
+            if (lastGcTime != 0 && delta > PAUSE_WARN_MS) {
+                DebugGuardian.LOGGER.warn("Long GC pause detected: {} ms", delta);
+            }
+            lastGcTime = totalGc;
+        }, 10, 10, TimeUnit.SECONDS);
+    }
+}

--- a/src/main/java/com/thunder/debugguardian/debug/monitor/LiveLogMonitor.java
+++ b/src/main/java/com/thunder/debugguardian/debug/monitor/LiveLogMonitor.java
@@ -39,6 +39,22 @@ public class LiveLogMonitor {
                 "Unexpected null value; mod instability possible.");
         errorClassifications.put("Exception in server tick loop",
                 "Fatal error during world tick; risk of corruption.");
+        errorClassifications.put("Missing registry",
+                "A registry entry could not be found; check mod versions.");
+        errorClassifications.put("Duplicate mod",
+                "Duplicate mod IDs detected; remove extras.");
+        errorClassifications.put("Invalid config",
+                "A configuration file failed to load; verify its contents.");
+        errorClassifications.put("Failed to handle handshake",
+                "Network handshake failed; a mod may be incompatible.");
+        errorClassifications.put("Resource reload failed",
+                "A resource pack failed to reload; check data or assets.");
+        errorClassifications.put("Registry remapping failed",
+                "Registry remapping failed during world load; check mod updates.");
+        errorClassifications.put("Error generating chunk",
+                "A chunk failed to generate; world may be corrupted.");
+        errorClassifications.put("Failed to save chunk",
+                "Chunk data failed to save; check disk health or mods.");
     }
 
     public static void start() {

--- a/src/main/java/com/thunder/debugguardian/debug/monitor/StartupFailureReporter.java
+++ b/src/main/java/com/thunder/debugguardian/debug/monitor/StartupFailureReporter.java
@@ -1,0 +1,22 @@
+package com.thunder.debugguardian.debug.monitor;
+
+import com.thunder.debugguardian.DebugGuardian;
+
+/**
+ * Installs a global uncaught exception handler early during startup so
+ * crashes during mod loading are recorded to the live log.
+ */
+public class StartupFailureReporter implements Thread.UncaughtExceptionHandler {
+    public static void install() {
+        Thread.setDefaultUncaughtExceptionHandler(new StartupFailureReporter());
+    }
+
+    @Override
+    public void uncaughtException(Thread t, Throwable e) {
+        LiveLogMonitor.captureThrowable(e);
+        String culprit = ClassLoadingIssueDetector.identifyCulpritMod(e);
+        if (!"Unknown".equals(culprit)) {
+            DebugGuardian.LOGGER.error("Startup crash likely caused by mod {}", culprit);
+        }
+    }
+}

--- a/src/main/java/com/thunder/debugguardian/debug/monitor/WorldGenProgressMonitor.java
+++ b/src/main/java/com/thunder/debugguardian/debug/monitor/WorldGenProgressMonitor.java
@@ -1,0 +1,43 @@
+package com.thunder.debugguardian.debug.monitor;
+
+import com.thunder.debugguardian.DebugGuardian;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.level.ChunkEvent;
+import net.neoforged.neoforge.event.level.LevelEvent;
+import net.neoforged.neoforge.event.tick.ServerTickEvent;
+
+import static com.thunder.debugguardian.DebugGuardian.MOD_ID;
+
+/**
+ * Tracks world-generation progress and warns if no chunks are
+ * generated for an extended period, which may indicate a stall
+ * at "0%" during world creation.
+ */
+@EventBusSubscriber(modid = MOD_ID)
+public class WorldGenProgressMonitor {
+    private static final long WARN_MS = 15_000; // 15 seconds
+    private static long lastChunkTime = -1;
+    private static boolean warned = false;
+
+    @SubscribeEvent
+    public static void onLevelLoad(LevelEvent.Load evt) {
+        lastChunkTime = System.currentTimeMillis();
+        warned = false;
+    }
+
+    @SubscribeEvent
+    public static void onChunkLoad(ChunkEvent.Load evt) {
+        lastChunkTime = System.currentTimeMillis();
+    }
+
+    @SubscribeEvent
+    public static void onServerTick(ServerTickEvent.Post evt) {
+        if (lastChunkTime < 0 || warned) return;
+        long elapsed = System.currentTimeMillis() - lastChunkTime;
+        if (elapsed > WARN_MS) {
+            DebugGuardian.LOGGER.warn("No chunks generated for {} ms; world gen may be stuck", elapsed);
+            warned = true;
+        }
+    }
+}

--- a/src/main/java/com/thunder/debugguardian/debug/monitor/WorldLoadMonitor.java
+++ b/src/main/java/com/thunder/debugguardian/debug/monitor/WorldLoadMonitor.java
@@ -1,0 +1,41 @@
+package com.thunder.debugguardian.debug.monitor;
+
+import com.thunder.debugguardian.DebugGuardian;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.Level;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.level.LevelEvent;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.thunder.debugguardian.DebugGuardian.MOD_ID;
+
+/**
+ * Watches dimension load/unload events and reports unusually slow loads.
+ */
+@EventBusSubscriber(modid = MOD_ID)
+public class WorldLoadMonitor {
+    private static final long WARN_MS = 5_000; // 5 seconds
+    private static final Map<ResourceKey<Level>, Long> unloadTimes = new ConcurrentHashMap<>();
+
+    @SubscribeEvent
+    public static void onLevelUnload(LevelEvent.Unload evt) {
+        Level level = (Level) evt.getLevel();
+        unloadTimes.put(level.dimension(), System.currentTimeMillis());
+    }
+
+    @SubscribeEvent
+    public static void onLevelLoad(LevelEvent.Load evt) {
+        Level level = (Level) evt.getLevel();
+        ResourceKey<Level> key = level.dimension();
+        Long start = unloadTimes.remove(key);
+        if (start != null) {
+            long dur = System.currentTimeMillis() - start;
+            if (dur > WARN_MS) {
+                DebugGuardian.LOGGER.warn("Dimension {} took {} ms to load", key.location(), dur);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- detect stalled world generation and warn if chunk progress halts
- map crash stack traces to mod jars for better culprit identification
- report offending mod on startup crashes
- flag chunk generation and save errors in live log monitor

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68a54337b2d48328a9e1a9c5d6075f64