### PR TITLE
fix: update LiveLogMonitor for new log4j AbstractAppender

### DIFF
--- a/src/main/java/com/thunder/debugguardian/debug/monitor/LiveLogMonitor.java
+++ b/src/main/java/com/thunder/debugguardian/debug/monitor/LiveLogMonitor.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.*;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.core.LogEvent;
 
@@ -80,7 +81,8 @@ public class LiveLogMonitor {
     private static class LiveAppender extends AbstractAppender {
         protected LiveAppender(String name) {
             super(name, new ErrorTracker(),
-                    PatternLayout.newBuilder().withPattern("%m").build(), false);
+                    PatternLayout.newBuilder().withPattern("%m").build(), false,
+                    Property.EMPTY_ARRAY);
             start();
         }
 


### PR DESCRIPTION
## Summary
- update LiveLogMonitor to use new AbstractAppender constructor with Property.EMPTY_ARRAY

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68a5ea11d91c83288d21aed057c88a4d