### PR TITLE
Detect culprit mod when world generation stalls at 0%

### DIFF
--- a/src/main/java/com/thunder/debugguardian/debug/monitor/WorldGenProgressMonitor.java
+++ b/src/main/java/com/thunder/debugguardian/debug/monitor/WorldGenProgressMonitor.java
@@ -16,7 +16,7 @@ import static com.thunder.debugguardian.DebugGuardian.MOD_ID;
  */
 @EventBusSubscriber(modid = MOD_ID)
 public class WorldGenProgressMonitor {
-    private static final long WARN_MS = 15_000; // 15 seconds
+    private static final long WARN_MS = 60_000; // 1 minute
     private static long lastChunkTime = -1;
     private static boolean warned = false;
 
@@ -36,8 +36,42 @@ public class WorldGenProgressMonitor {
         if (lastChunkTime < 0 || warned) return;
         long elapsed = System.currentTimeMillis() - lastChunkTime;
         if (elapsed > WARN_MS) {
-            DebugGuardian.LOGGER.warn("No chunks generated for {} ms; world gen may be stuck", elapsed);
+            Thread serverThread = findServerThread();
+            String culprit = serverThread != null
+                    ? ClassLoadingIssueDetector.identifyCulpritMod(serverThread.getStackTrace())
+                    : "Unknown";
+            if ("Unknown".equals(culprit)) {
+                culprit = findCulpritAcrossThreads();
+            }
+            if (!"Unknown".equals(culprit)) {
+                DebugGuardian.LOGGER.warn("World gen stuck at 0% for {} ms; possible culprit mod {}", elapsed, culprit);
+            } else {
+                DebugGuardian.LOGGER.warn("World gen stuck at 0% for {} ms; culprit unknown", elapsed);
+            }
             warned = true;
         }
+    }
+
+    private static Thread findServerThread() {
+        for (Thread t : Thread.getAllStackTraces().keySet()) {
+            if ("Server thread".equals(t.getName())) {
+                return t;
+            }
+        }
+        return null;
+    }
+
+    private static String findCulpritAcrossThreads() {
+        java.util.Map<String, Integer> counts = new java.util.HashMap<>();
+        for (java.util.Map.Entry<Thread, StackTraceElement[]> e : Thread.getAllStackTraces().entrySet()) {
+            String mod = ClassLoadingIssueDetector.identifyCulpritMod(e.getValue());
+            if (!"Unknown".equals(mod)) {
+                counts.merge(mod, 1, Integer::sum);
+            }
+        }
+        return counts.entrySet().stream()
+                .max(java.util.Map.Entry.comparingByValue())
+                .map(java.util.Map.Entry::getKey)
+                .orElse("Unknown");
     }
 }


### PR DESCRIPTION
## Summary
- Detect mods responsible when world generation sits at 0% for over a minute
- Search server thread stack trace to identify culprit mod and fall back to scanning all threads if needed

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68a68b7bed0c8328b66b926c1094441c