### PR TITLE
Fix duplicate variable declarations in WorldHangDetector

### DIFF
--- a/src/main/java/com/thunder/debugguardian/debug/monitor/WorldHangDetector.java
+++ b/src/main/java/com/thunder/debugguardian/debug/monitor/WorldHangDetector.java
@@ -91,12 +91,6 @@ public class WorldHangDetector {
                         "Server thread {} unresponsive for {} ms; waiting on {} owned by {}; blocked at {} via {} (mod: {})",
                         serverThread.getState(), elapsed, lock, owner, top, culpritFrame, culprit);
 
-                String culprit = ClassLoadingIssueDetector.identifyCulpritMod(stack);
-                StackTraceElement top = stack.length > 0 ? stack[0] : null;
-                DebugGuardian.LOGGER.warn(
-                        "Server thread {} unresponsive for {} ms; possible culprit mod {} at {}",
-                        serverThread.getState(), elapsed, culprit, top);
-
                 if (DebugGuardian.LOGGER.isDebugEnabled()) {
                     for (StackTraceElement element : stack) {
                         DebugGuardian.LOGGER.debug("    at {}", element);


### PR DESCRIPTION
## Summary
- Remove redundant `culprit` and `top` declarations in `WorldHangDetector`
- Keep a single detailed warning for server thread hangs

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68aa03238fdc8328af41a3e1c1192e06