### PR TITLE
Add force close debug detector and helper process

### DIFF
--- a/src/main/java/com/thunder/debugguardian/DebugGuardian.java
+++ b/src/main/java/com/thunder/debugguardian/DebugGuardian.java
@@ -9,6 +9,7 @@ import com.thunder.debugguardian.debug.monitor.WorldGenFreezeDetector;
 import com.thunder.debugguardian.debug.monitor.GcPauseMonitor;
 import com.thunder.debugguardian.debug.monitor.WorldHangDetector;
 import com.thunder.debugguardian.debug.monitor.StartupFailureReporter;
+import com.thunder.debugguardian.debug.monitor.ForceCloseDetector;
 import com.thunder.debugguardian.debug.replay.PostMortemRecorder;
 import com.thunder.debugguardian.util.UnusedConfigScanner;
 import net.minecraft.network.FriendlyByteBuf;
@@ -80,6 +81,7 @@ public class DebugGuardian {
         ThreadUsageMonitor.start();
         GcPauseMonitor.start();
         WorldHangDetector.start();
+        ForceCloseDetector.start();
 
     }
 

--- a/src/main/java/com/thunder/debugguardian/config/DebugConfig.java
+++ b/src/main/java/com/thunder/debugguardian/config/DebugConfig.java
@@ -45,6 +45,15 @@ public class DebugConfig {
             .comment("Number of identical errors to skip before logging again")
             .defineInRange("logging.errorReportInterval", 100, 1, 10000);
 
+    // Force Close Debugging Settings
+    public static final ModConfigSpec.BooleanValue FORCE_CLOSE_ENABLE = BUILDER
+            .comment("Enable capturing mod stacks when the game is forcibly closed")
+            .define("debug.forceClose.enable", true);
+
+    public static final ModConfigSpec.BooleanValue FORCE_CLOSE_LAUNCH_HELPER = BUILDER
+            .comment("Launch a helper JVM alongside the game for deeper debugging")
+            .define("debug.forceClose.launchHelper", false);
+
     public static final ModConfigSpec SPEC = BUILDER.build();
 
 
@@ -56,6 +65,8 @@ public class DebugConfig {
     public final boolean compatibilityEnableScan;
     public final boolean loggingEnableLiveMonitor;
     public final int loggingErrorReportInterval;
+    public final boolean forceCloseEnable;
+    public final boolean forceCloseLaunchHelper;
 
     private DebugConfig() {
         this.postmortemBufferSize = POSTMORTEM_BUFFER_SIZE.get();
@@ -65,6 +76,8 @@ public class DebugConfig {
         this.compatibilityEnableScan = COMPAT_ENABLE_SCAN.get();
         this.loggingEnableLiveMonitor = LOGGING_ENABLE_LIVE.get();
         this.loggingErrorReportInterval = LOGGING_ERROR_REPORT_INTERVAL.get();
+        this.forceCloseEnable = FORCE_CLOSE_ENABLE.get();
+        this.forceCloseLaunchHelper = FORCE_CLOSE_LAUNCH_HELPER.get();
     }
 
     public static DebugConfig get() {

--- a/src/main/java/com/thunder/debugguardian/debug/external/DebugHelper.java
+++ b/src/main/java/com/thunder/debugguardian/debug/external/DebugHelper.java
@@ -1,0 +1,14 @@
+package com.thunder.debugguardian.debug.external;
+
+/**
+ * Simple helper application launched in a separate JVM when debug mode is
+ * enabled. It currently acts as a placeholder where advanced diagnostic logic
+ * could be implemented.
+ */
+public class DebugHelper {
+    public static void main(String[] args) throws Exception {
+        System.out.println("Debug helper process running");
+        // Keep the process alive so tooling can attach if desired.
+        Thread.sleep(Long.MAX_VALUE);
+    }
+}

--- a/src/main/java/com/thunder/debugguardian/debug/monitor/ForceCloseDetector.java
+++ b/src/main/java/com/thunder/debugguardian/debug/monitor/ForceCloseDetector.java
@@ -1,0 +1,80 @@
+package com.thunder.debugguardian.debug.monitor;
+
+import com.thunder.debugguardian.DebugGuardian;
+import com.thunder.debugguardian.config.DebugConfig;
+import net.neoforged.fml.loading.FMLPaths;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+
+/**
+ * Registers a shutdown hook that captures thread stacks when the game is
+ * forcibly closed. The stacks are analysed to identify potential mod culprits
+ * and written to a timestamped log file for later inspection.
+ *
+ * Optionally launches a helper JVM process when enabled via config to allow
+ * deeper debugging or attachment of external tools.
+ */
+public class ForceCloseDetector {
+    private static final Path DUMP_DIR = FMLPaths.GAMEDIR.get().resolve("debugguardian");
+
+    /** Starts the detector and optional helper process based on config. */
+    public static void start() {
+        DebugConfig cfg = DebugConfig.get();
+        if (!cfg.forceCloseEnable) {
+            return;
+        }
+
+        if (cfg.forceCloseLaunchHelper) {
+            launchHelper();
+        }
+
+        Runtime.getRuntime().addShutdownHook(new Thread(ForceCloseDetector::dumpStacks,
+                "debugguardian-force-close"));
+    }
+
+    private static void dumpStacks() {
+        try {
+            Files.createDirectories(DUMP_DIR);
+            String ts = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
+            Path file = DUMP_DIR.resolve("force-close-" + ts + ".log");
+            try (BufferedWriter writer = Files.newBufferedWriter(file, StandardOpenOption.CREATE_NEW)) {
+                ThreadMXBean bean = ManagementFactory.getThreadMXBean();
+                for (Map.Entry<Thread, StackTraceElement[]> e : Thread.getAllStackTraces().entrySet()) {
+                    Thread t = e.getKey();
+                    StackTraceElement[] stack = e.getValue();
+                    String mod = ClassLoadingIssueDetector.identifyCulpritMod(stack);
+                    writer.write("Thread: " + t.getName() + " mod: " + mod);
+                    writer.newLine();
+                    for (StackTraceElement ste : stack) {
+                        writer.write("    at " + ste);
+                        writer.newLine();
+                    }
+                    writer.newLine();
+                }
+            }
+            DebugGuardian.LOGGER.warn("Force-close thread dump written to {}", file);
+        } catch (IOException e) {
+            DebugGuardian.LOGGER.error("Failed to write force-close dump", e);
+        }
+    }
+
+    private static void launchHelper() {
+        try {
+            new ProcessBuilder("java", "-cp", System.getProperty("java.class.path"),
+                    "com.thunder.debugguardian.debug.external.DebugHelper").start();
+            DebugGuardian.LOGGER.info("Debug helper process launched");
+        } catch (IOException e) {
+            DebugGuardian.LOGGER.error("Failed to launch debug helper process", e);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- log thread stacks and mod involvement when the game is forcibly closed
- optional helper JVM launched in debug mode to aid investigation
- expose new config flags for force-close monitoring and helper launch

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68c060d28c0c8328ae7dbb879f20c911