### PR TITLE
Add compat config and helper logging

### DIFF
--- a/src/main/java/com/thunder/debugguardian/debug/compat/CompatibilityScanner.java
+++ b/src/main/java/com/thunder/debugguardian/debug/compat/CompatibilityScanner.java
@@ -1,5 +1,6 @@
 package com.thunder.debugguardian.debug.compat;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.thunder.debugguardian.DebugGuardian;
@@ -11,6 +12,7 @@ import net.neoforged.fml.event.lifecycle.FMLLoadCompleteEvent;
 import net.neoforged.fml.loading.FMLPaths;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -23,6 +25,18 @@ public class CompatibilityScanner {
         if (!DebugConfig.get().compatibilityEnableScan) return;
         try {
             Path json = FMLPaths.CONFIGDIR.get().resolve("compatibility.json");
+            if (Files.notExists(json)) {
+                try (InputStream in = CompatibilityScanner.class.getResourceAsStream("/compatibility.json")) {
+                    if (in != null) {
+                        Files.copy(in, json);
+                    } else {
+                        JsonObject tmpl = new JsonObject();
+                        tmpl.add("incompatibilities", new JsonArray());
+                        Files.writeString(json, tmpl.toString());
+                    }
+                }
+            }
+
             JsonObject root = JsonParser.parseString(Files.readString(json)).getAsJsonObject();
             root.getAsJsonArray("incompatibilities").forEach(el -> {
                 JsonObject obj = el.getAsJsonObject();

--- a/src/main/java/com/thunder/debugguardian/debug/monitor/ForceCloseDetector.java
+++ b/src/main/java/com/thunder/debugguardian/debug/monitor/ForceCloseDetector.java
@@ -34,6 +34,7 @@ public class ForceCloseDetector {
         }
 
         if (cfg.forceCloseLaunchHelper) {
+            DebugGuardian.LOGGER.info("forceClose.launchHelper enabled; starting helper JVM");
             launchHelper();
         }
 
@@ -70,7 +71,9 @@ public class ForceCloseDetector {
     private static void launchHelper() {
         try {
             new ProcessBuilder("java", "-cp", System.getProperty("java.class.path"),
-                    "com.thunder.debugguardian.debug.external.DebugHelper").start();
+                    "com.thunder.debugguardian.debug.external.DebugHelper")
+                    .inheritIO()
+                    .start();
             DebugGuardian.LOGGER.info("Debug helper process launched");
         } catch (IOException e) {
             DebugGuardian.LOGGER.error("Failed to launch debug helper process", e);

--- a/src/main/resources/compatibility.json
+++ b/src/main/resources/compatibility.json
@@ -1,0 +1,10 @@
+{
+  "incompatibilities": [
+    {
+      "modA": "examplemod",
+      "modB": "othermod",
+      "reason": "Describe the incompatibility here"
+    }
+  ]
+}
+


### PR DESCRIPTION
## Summary
- Create default `compatibility.json` in config dir when missing
- Log and expose output from optional helper JVM
- Ship sample `compatibility.json`

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68c07dbb11d4832880e41b907ec4e798