### PR TITLE
Launch helper JVM when configured

### DIFF
--- a/src/main/java/com/thunder/debugguardian/debug/monitor/ForceCloseDetector.java
+++ b/src/main/java/com/thunder/debugguardian/debug/monitor/ForceCloseDetector.java
@@ -26,16 +26,20 @@ import java.util.Map;
 public class ForceCloseDetector {
     private static final Path DUMP_DIR = FMLPaths.GAMEDIR.get().resolve("debugguardian");
 
-    /** Starts the detector and optional helper process based on config. */
+    /**
+     * Starts the optional helper process and, if enabled, the force-close
+     * shutdown hook detector.
+     */
     public static void start() {
         DebugConfig cfg = DebugConfig.get();
-        if (!cfg.forceCloseEnable) {
-            return;
-        }
 
         if (cfg.forceCloseLaunchHelper) {
             DebugGuardian.LOGGER.info("forceClose.launchHelper enabled; starting helper JVM");
             launchHelper();
+        }
+
+        if (!cfg.forceCloseEnable) {
+            return;
         }
 
         Runtime.getRuntime().addShutdownHook(new Thread(ForceCloseDetector::dumpStacks,


### PR DESCRIPTION
## Summary
- Start optional debug helper JVM when configuration flag `debug.forceClose.launchHelper` is true, even if force-close detection is disabled
- Clarify start method comment accordingly

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68c191d865908328815c5503fb80b9d8