### PR TITLE
Enhance debug helper with suspect mod report

### DIFF
--- a/src/main/java/com/thunder/debugguardian/debug/external/DebugHelper.java
+++ b/src/main/java/com/thunder/debugguardian/debug/external/DebugHelper.java
@@ -4,13 +4,20 @@ import com.google.gson.Gson;
 
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Helper application launched in a separate JVM when debug mode is enabled.
@@ -35,22 +42,39 @@ public class DebugHelper {
         try {
             Path dumpFile = waitForDumpFile(dumpDir);
             List<ThreadReport> report = parseDump(dumpFile);
-            Path out = dumpDir.resolve("analysis-" + timestamp() + ".json");
+            String ts = timestamp();
+            Path out = dumpDir.resolve("analysis-" + ts + ".json");
             Files.writeString(out, new Gson().toJson(report));
             System.out.println("Analysis written to " + out);
+            writeSummary(dumpDir, report, ts);
+            writeSuspects(dumpDir, report, ts);
         } catch (Exception e) {
             e.printStackTrace();
         }
     }
 
     private static Path waitForDumpFile(Path dir) throws InterruptedException, IOException {
-        while (true) {
-            try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir, "force-close-*.log")) {
-                for (Path p : stream) {
-                    return p;
-                }
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir, "force-close-*.log")) {
+            for (Path p : stream) {
+                return p;
             }
-            Thread.sleep(1000);
+        }
+
+        try (WatchService watcher = FileSystems.getDefault().newWatchService()) {
+            dir.register(watcher, StandardWatchEventKinds.ENTRY_CREATE);
+
+            while (true) {
+                WatchKey key = watcher.take();
+                for (WatchEvent<?> event : key.pollEvents()) {
+                    if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
+                        Path name = (Path) event.context();
+                        if (name.toString().startsWith("force-close-") && name.toString().endsWith(".log")) {
+                            return dir.resolve(name);
+                        }
+                    }
+                }
+                key.reset();
+            }
         }
     }
 
@@ -86,6 +110,28 @@ public class DebugHelper {
         }
 
         return threads;
+    }
+
+    private static void writeSummary(Path dir, List<ThreadReport> report, String ts) throws IOException {
+        List<String> lines = new ArrayList<>();
+        for (ThreadReport tr : report) {
+            lines.add(tr.thread() + " - " + tr.mod() + " (" + tr.stack().size() + " frames)");
+        }
+        Path summary = dir.resolve("summary-" + ts + ".txt");
+        Files.write(summary, lines);
+        System.out.println("Summary written to " + summary);
+    }
+
+    private static void writeSuspects(Path dir, List<ThreadReport> report, String ts) throws IOException {
+        Map<String, Long> counts = report.stream()
+                .collect(Collectors.groupingBy(ThreadReport::mod, Collectors.counting()));
+        List<String> lines = counts.entrySet().stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                .map(e -> e.getKey() + " - " + e.getValue() + " thread(s)")
+                .toList();
+        Path suspects = dir.resolve("suspects-" + ts + ".txt");
+        Files.write(suspects, lines);
+        System.out.println("Suspects written to " + suspects);
     }
 
     private static String timestamp() {


### PR DESCRIPTION
## Summary
- watch force-close logs with try-with-resources to ensure watcher cleanup
- output `suspects-*.txt` listing mods by thread count for quicker culprit identification

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68c2df0741688328a6fa3e3d0b31961c