### PR TITLE
Improve watchdog shutdown and config scanning

### DIFF
--- a/src/main/java/com/thunder/debugguardian/DebugGuardian.java
+++ b/src/main/java/com/thunder/debugguardian/DebugGuardian.java
@@ -24,6 +24,7 @@ import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
 import net.neoforged.neoforge.event.server.ServerStartingEvent;
+import net.neoforged.neoforge.event.server.ServerStoppingEvent;
 import net.neoforged.neoforge.network.handling.IPayloadHandler;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -92,6 +93,11 @@ public class DebugGuardian {
     @SubscribeEvent
     public void onServerStarting(ServerStartingEvent event) {
         UnusedConfigScanner.scanForUnusedConfigs(event.getServer());
+    }
+
+    @SubscribeEvent
+    public void onServerStopping(ServerStoppingEvent event) {
+        Watchdog.stop();
     }
 }
 

--- a/src/main/java/com/thunder/debugguardian/util/UnusedConfigScanner.java
+++ b/src/main/java/com/thunder/debugguardian/util/UnusedConfigScanner.java
@@ -6,7 +6,6 @@ import net.neoforged.fml.ModList;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -20,21 +19,18 @@ public class UnusedConfigScanner {
     public static void scanForUnusedConfigs(MinecraftServer server) {
         if (!Files.isDirectory(CONFIG_FOLDER)) return;
 
-        try {
-            List<Path> files = Files.list(CONFIG_FOLDER)
-                    .filter(p -> p.toString().endsWith(".toml"))
-                    .toList();
-
-            for (Path file : files) {
-                String fileName = file.getFileName().toString();
-                Matcher matcher = MODID_PATTERN.matcher(fileName);
-                if (matcher.matches()) {
-                    String modid = matcher.group(1);
-                    if (!ModList.get().isLoaded(modid)) {
-                        LOGGER.warn("[DebugGuardian] Unused config detected: '{}' (mod '{}' not loaded)", fileName, modid);
-                    }
-                }
-            }
+        try (var stream = Files.list(CONFIG_FOLDER)) {
+            stream.filter(p -> p.toString().endsWith(".toml"))
+                    .forEach(file -> {
+                        String fileName = file.getFileName().toString();
+                        Matcher matcher = MODID_PATTERN.matcher(fileName);
+                        if (matcher.matches()) {
+                            String modid = matcher.group(1);
+                            if (!ModList.get().isLoaded(modid)) {
+                                LOGGER.warn("[DebugGuardian] Unused config detected: '{}' (mod '{}' not loaded)", fileName, modid);
+                            }
+                        }
+                    });
 
         } catch (IOException e) {
             LOGGER.error("[DebugGuardian] Failed to scan config folder: ", e);


### PR DESCRIPTION
## Summary
- give Watchdog a named daemon thread and shutdown hook
- stop Watchdog when the server stops
- close config directory stream when scanning for unused configs

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c2e40599008328ac80bc207af7c06e