### PR TITLE
Add configurable API key for AI log analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ monitors crash dumps. It now parses force-close logs and generates multiple
 reports including a heuristic explanation of likely causes. The analyzer is
 structured so that future versions can hook into an AI service for deeper log
 diagnostics. By default the helper uses a simple heuristic implementation, but
-if the environment variable `DEBUG_GUARDIAN_AI_KEY` is defined it will attempt
-to contact an external service using that key via `AiLogAnalyzer`.
+if the config value `logging.aiServiceApiKey` or the environment variable
+`DEBUG_GUARDIAN_AI_KEY` is defined it will attempt to contact an external
+service using that key via `AiLogAnalyzer`.
 
 The included `AiLogAnalyzer` class demonstrates how an AI service could be
-invoked. It reads the API key from `DEBUG_GUARDIAN_AI_KEY` and contains a
+invoked. It first reads the API key from the `logging.aiServiceApiKey` config
+entry, then falls back to `DEBUG_GUARDIAN_AI_KEY`, and finally uses a
 placeholder that must be replaced with a real key before any external requests
 are made.
 

--- a/src/main/java/com/thunder/debugguardian/config/DebugConfig.java
+++ b/src/main/java/com/thunder/debugguardian/config/DebugConfig.java
@@ -40,6 +40,11 @@ public class DebugConfig {
             .comment("Enable real-time in-game log monitoring and notifications")
             .define("logging.enableLiveMonitor", true);
 
+    // AI Log Analyzer Settings
+    public static final ModConfigSpec.ConfigValue<String> LOGGING_AI_SERVICE_API_KEY = BUILDER
+            .comment("API key for external AI log analyzer; blank uses DEBUG_GUARDIAN_AI_KEY env var")
+            .define("logging.aiServiceApiKey", "");
+
     // Error Tracking Settings
     public static final ModConfigSpec.IntValue LOGGING_ERROR_REPORT_INTERVAL = BUILDER
             .comment("Number of identical errors to skip before logging again")
@@ -64,6 +69,7 @@ public class DebugConfig {
     public final double performanceMemoryWarningRatio;
     public final boolean compatibilityEnableScan;
     public final boolean loggingEnableLiveMonitor;
+    public final String loggingAiServiceApiKey;
     public final int loggingErrorReportInterval;
     public final boolean forceCloseEnable;
     public final boolean forceCloseLaunchHelper;
@@ -75,6 +81,7 @@ public class DebugConfig {
         this.performanceMemoryWarningRatio = PERFORMANCE_MEMORY_RATIO.get();
         this.compatibilityEnableScan = COMPAT_ENABLE_SCAN.get();
         this.loggingEnableLiveMonitor = LOGGING_ENABLE_LIVE.get();
+        this.loggingAiServiceApiKey = LOGGING_AI_SERVICE_API_KEY.get();
         this.loggingErrorReportInterval = LOGGING_ERROR_REPORT_INTERVAL.get();
         this.forceCloseEnable = FORCE_CLOSE_ENABLE.get();
         this.forceCloseLaunchHelper = FORCE_CLOSE_LAUNCH_HELPER.get();

--- a/src/main/java/com/thunder/debugguardian/debug/external/AiLogAnalyzer.java
+++ b/src/main/java/com/thunder/debugguardian/debug/external/AiLogAnalyzer.java
@@ -1,5 +1,7 @@
 package com.thunder.debugguardian.debug.external;
 
+import com.thunder.debugguardian.config.DebugConfig;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,11 +29,12 @@ public class AiLogAnalyzer implements LogAnalyzer {
     private final String apiKey;
 
     /**
-     * Creates an analyzer using the {@code DEBUG_GUARDIAN_AI_KEY} environment
-     * variable or a placeholder if not present.
+     * Creates an analyzer using the {@code logging.aiServiceApiKey} config
+     * value, falling back to the {@code DEBUG_GUARDIAN_AI_KEY} environment
+     * variable or a placeholder if neither is present.
      */
     public AiLogAnalyzer() {
-        this(System.getenv().getOrDefault("DEBUG_GUARDIAN_AI_KEY", "REPLACE_WITH_REAL_AI_KEY"));
+        this(resolveApiKey());
     }
 
     /**
@@ -39,6 +42,14 @@ public class AiLogAnalyzer implements LogAnalyzer {
      */
     public AiLogAnalyzer(String apiKey) {
         this.apiKey = apiKey;
+    }
+
+    private static String resolveApiKey() {
+        String key = DebugConfig.get().loggingAiServiceApiKey;
+        if (key == null || key.isEmpty()) {
+            key = System.getenv().getOrDefault("DEBUG_GUARDIAN_AI_KEY", "REPLACE_WITH_REAL_AI_KEY");
+        }
+        return key;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- add `logging.aiServiceApiKey` config option to expose an AI service key
- have `AiLogAnalyzer` prefer config value before environment variable
- document the new config option in the README

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68c447633fa88328af768affcb20dd99