### PR TITLE
Track thread state in crash reports

### DIFF
--- a/src/main/java/com/thunder/debugguardian/debug/external/AiLogAnalyzer.java
+++ b/src/main/java/com/thunder/debugguardian/debug/external/AiLogAnalyzer.java
@@ -85,7 +85,8 @@ public class AiLogAnalyzer implements LogAnalyzer {
                     .map(frame -> "\"" + escape(frame) + "\"")
                     .collect(Collectors.joining(","));
             return "{\"thread\":\"" + escape(tr.thread()) + "\",\"mod\":\"" +
-                    escape(tr.mod()) + "\",\"stack\":[" + stack + "]}";
+                    escape(tr.mod()) + "\",\"state\":\"" + escape(tr.state()) +
+                    "\",\"stack\":[" + stack + "]}";
         }).collect(Collectors.joining(","));
         return "{\"threads\":[" + threadJson + "]}";
     }

--- a/src/main/java/com/thunder/debugguardian/debug/external/BasicLogAnalyzer.java
+++ b/src/main/java/com/thunder/debugguardian/debug/external/BasicLogAnalyzer.java
@@ -22,7 +22,7 @@ public class BasicLogAnalyzer implements LogAnalyzer {
 
         for (ThreadReport tr : threads) {
             String topFrame = tr.stack().isEmpty() ? "unknown" : tr.stack().get(0);
-            sb.append(tr.thread()).append('\n')
+            sb.append(tr.thread()).append(" [").append(tr.state()).append("]\n")
               .append("  suspect mod: ").append(tr.mod()).append('\n')
               .append("  top frame: ").append(topFrame).append("\n\n");
         }

--- a/src/main/java/com/thunder/debugguardian/debug/external/ThreadReport.java
+++ b/src/main/java/com/thunder/debugguardian/debug/external/ThreadReport.java
@@ -3,6 +3,7 @@ package com.thunder.debugguardian.debug.external;
 import java.util.List;
 
 /**
- * Represents information about a single thread extracted from a dump file.
+ * Represents information about a single thread extracted from a dump file,
+ * including the associated mod, current thread state, and full stack trace.
  */
-public record ThreadReport(String thread, String mod, List<String> stack) {}
+public record ThreadReport(String thread, String mod, String state, List<String> stack) {}


### PR DESCRIPTION
## Summary
- parse and store thread state when reading force-close logs
- include thread state in report summaries and heuristic analysis
- transmit thread state to optional AI log analyzer

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c4caf58be083288d6db37f5bece5a2