### PR TITLE
Implement AI log analyzer with fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@ When debug mode is enabled the project launches a small helper application that
 monitors crash dumps. It now parses force-close logs and generates multiple
 reports including a heuristic explanation of likely causes. The analyzer is
 structured so that future versions can hook into an AI service for deeper log
-diagnostics. By default the helper uses a simple heuristic implementation, but
-if the config value `logging.aiServiceApiKey` or the environment variable
-`DEBUG_GUARDIAN_AI_KEY` is defined it will attempt to contact an external
-service using that key via `AiLogAnalyzer`.
+diagnostics. If the config value `logging.aiServiceApiKey` or the environment
+variable `DEBUG_GUARDIAN_AI_KEY` is defined the helper contacts OpenAI using
+`AiLogAnalyzer` to generate an explanation. When no key is provided the
+analyzer automatically falls back to the built-in heuristic
+`BasicLogAnalyzer`.
 
-The included `AiLogAnalyzer` class demonstrates how an AI service could be
-invoked. It first reads the API key from the `logging.aiServiceApiKey` config
-entry, then falls back to `DEBUG_GUARDIAN_AI_KEY`, and finally uses a
-placeholder that must be replaced with a real key before any external requests
-are made.
+The included `AiLogAnalyzer` class sends thread reports to the OpenAI Chat
+Completions API. It first reads the API key from the `logging.aiServiceApiKey`
+config entry, then falls back to `DEBUG_GUARDIAN_AI_KEY`. If neither is
+supplied it invokes the heuristic analyzer instead.
 
 Mapping Names:
 ============

--- a/src/main/java/com/thunder/debugguardian/debug/external/AiLogAnalyzer.java
+++ b/src/main/java/com/thunder/debugguardian/debug/external/AiLogAnalyzer.java
@@ -16,22 +16,22 @@ import java.util.stream.Collectors;
 /**
  * Log analyzer that delegates analysis to an external AI service over HTTP.
  * <p>
- * The implementation demonstrates how thread reports could be serialized and
- * sent to an AI endpoint. It reads an API key from the environment variable
- * {@code DEBUG_GUARDIAN_AI_KEY} and falls back to a hard-coded placeholder if
- * the variable is not defined. The sample URL must be replaced with a real
- * service before use.
+ * This implementation calls the OpenAI chat completions endpoint. If no API
+ * key is configured via the {@code logging.aiServiceApiKey} config value or the
+ * {@code DEBUG_GUARDIAN_AI_KEY} environment variable, the analyzer falls back
+ * to {@link BasicLogAnalyzer} to provide a heuristic explanation.
  */
 public class AiLogAnalyzer implements LogAnalyzer {
-    // Placeholder API endpoint URL
-    private static final String API_URL = "https://api.example.com/analyze";
+    private static final String API_URL = "https://api.openai.com/v1/chat/completions";
+    private static final String MODEL = "gpt-4o-mini";
 
     private final String apiKey;
+    private final BasicLogAnalyzer fallback = new BasicLogAnalyzer();
 
     /**
      * Creates an analyzer using the {@code logging.aiServiceApiKey} config
      * value, falling back to the {@code DEBUG_GUARDIAN_AI_KEY} environment
-     * variable or a placeholder if neither is present.
+     * variable if the config entry is blank.
      */
     public AiLogAnalyzer() {
         this(resolveApiKey());
@@ -46,16 +46,26 @@ public class AiLogAnalyzer implements LogAnalyzer {
 
     private static String resolveApiKey() {
         String key = DebugConfig.get().loggingAiServiceApiKey;
-        if (key == null || key.isEmpty()) {
-            key = System.getenv().getOrDefault("DEBUG_GUARDIAN_AI_KEY", "REPLACE_WITH_REAL_AI_KEY");
+        if (key == null || key.isBlank()) {
+            key = System.getenv("DEBUG_GUARDIAN_AI_KEY");
         }
-        return key;
+        return (key == null || key.isBlank()) ? null : key;
     }
 
     @Override
     public String analyze(List<ThreadReport> threads) {
+        if (apiKey == null || apiKey.isBlank()) {
+            return fallback.analyze(threads);
+        }
+
         try {
-            String payload = buildPayload(threads);
+            String message = buildMessage(threads);
+            String payload = "{" +
+                    "\"model\":\"" + MODEL + "\"," +
+                    "\"messages\":[{" +
+                    "\"role\":\"system\",\"content\":\"You are a Minecraft crash analysis assistant.\"},{" +
+                    "\"role\":\"user\",\"content\":\"" + escape(message) + "\"}]" +
+                    "}";
 
             HttpURLConnection connection = (HttpURLConnection) new URL(API_URL).openConnection();
             connection.setRequestMethod("POST");
@@ -67,28 +77,44 @@ public class AiLogAnalyzer implements LogAnalyzer {
                 os.write(payload.getBytes(StandardCharsets.UTF_8));
             }
 
-            int status = connection.getResponseCode();
-            InputStream responseStream = status >= 200 && status < 300
+            InputStream responseStream = connection.getResponseCode() >= 200 && connection.getResponseCode() < 300
                     ? connection.getInputStream()
                     : connection.getErrorStream();
 
             String response = readAll(responseStream);
-            return response.isEmpty() ? "AI service returned empty response." : response;
+            String content = extractContent(response);
+            return (content == null || content.isBlank())
+                    ? "AI service returned empty response." : content;
         } catch (IOException e) {
             return "Failed to contact AI service: " + e.getMessage();
         }
     }
 
-    private String buildPayload(List<ThreadReport> threads) {
-        String threadJson = threads.stream().map(tr -> {
-            String stack = tr.stack().stream()
-                    .map(frame -> "\"" + escape(frame) + "\"")
-                    .collect(Collectors.joining(","));
-            return "{\"thread\":\"" + escape(tr.thread()) + "\",\"mod\":\"" +
-                    escape(tr.mod()) + "\",\"state\":\"" + escape(tr.state()) +
-                    "\",\"stack\":[" + stack + "]}";
-        }).collect(Collectors.joining(","));
-        return "{\"threads\":[" + threadJson + "]}";
+    /**
+     * Build a plain-text message describing the thread dump that will be sent to
+     * the AI service.
+     */
+    private String buildMessage(List<ThreadReport> threads) {
+        StringBuilder sb = new StringBuilder();
+        for (ThreadReport tr : threads) {
+            sb.append("Thread ").append(tr.thread()).append(" [").append(tr.state()).append("] mod: ")
+              .append(tr.mod()).append("\n");
+            for (String frame : tr.stack()) {
+                sb.append("  ").append(frame).append("\n");
+            }
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+
+    private static String extractContent(String json) {
+        int idx = json.indexOf("\"content\":\"");
+        if (idx == -1) return null;
+        idx += 11; // length of "content":"
+        int end = json.indexOf("\"", idx);
+        if (end == -1) return null;
+        String content = json.substring(idx, end);
+        return content.replace("\\n", "\n");
     }
 
     private static String readAll(InputStream is) throws IOException {
@@ -101,3 +127,4 @@ public class AiLogAnalyzer implements LogAnalyzer {
         return s.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 }
+

--- a/src/main/java/com/thunder/debugguardian/debug/external/DebugHelper.java
+++ b/src/main/java/com/thunder/debugguardian/debug/external/DebugHelper.java
@@ -166,10 +166,7 @@ public class DebugHelper {
     }
 
     private static void writeExplanation(Path dir, List<ThreadReport> report, String ts) throws IOException {
-        String apiKey = System.getenv("DEBUG_GUARDIAN_AI_KEY");
-        LogAnalyzer analyzer = (apiKey != null && !apiKey.isBlank())
-                ? new AiLogAnalyzer(apiKey)
-                : new BasicLogAnalyzer();
+        LogAnalyzer analyzer = new AiLogAnalyzer();
         String explanation = analyzer.analyze(report);
         Path file = dir.resolve("explanation-" + ts + ".txt");
         Files.writeString(file, explanation);


### PR DESCRIPTION
## Summary
- Connect `AiLogAnalyzer` to OpenAI's chat completions API
- Automatically fall back to heuristic `BasicLogAnalyzer` when no API key is configured
- Update `DebugHelper` and documentation for new analyzer behavior

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c4fe2f1c0483288a3352f3a0b7a2a4