### PR TITLE
Add crash debug command

### DIFF
--- a/src/main/java/com/thunder/debugguardian/debug/command/CrashCommand.java
+++ b/src/main/java/com/thunder/debugguardian/debug/command/CrashCommand.java
@@ -1,0 +1,29 @@
+package com.thunder.debugguardian.debug.command;
+
+import net.minecraft.commands.Commands;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.RegisterCommandsEvent;
+
+import static com.thunder.debugguardian.DebugGuardian.MOD_ID;
+
+/**
+ * Registers a simple command that intentionally crashes the game.
+ * Useful for verifying debugging and crash handling tools.
+ */
+@EventBusSubscriber(modid = MOD_ID)
+public class CrashCommand {
+    private CrashCommand() {
+    }
+
+    @SubscribeEvent
+    public static void onRegisterCommands(RegisterCommandsEvent event) {
+        event.getDispatcher().register(
+            Commands.literal("crash")
+                .requires(source -> source.hasPermission(2))
+                .executes(ctx -> {
+                    throw new RuntimeException("Intentional crash triggered by /crash command");
+                })
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add `/crash` command that intentionally throws an exception for debugging

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68c5a6a1ecb48328a90ed511d5ba826b