### PR TITLE
Load config before AI analysis in debug helper

### DIFF
--- a/src/main/java/com/thunder/debugguardian/debug/monitor/ForceCloseDetector.java
+++ b/src/main/java/com/thunder/debugguardian/debug/monitor/ForceCloseDetector.java
@@ -76,7 +76,8 @@ public class ForceCloseDetector {
         try {
             new ProcessBuilder("java", "-cp", System.getProperty("java.class.path"),
                     "com.thunder.debugguardian.debug.external.DebugHelper",
-                    DUMP_DIR.toString())
+                    DUMP_DIR.toString(),
+                    FMLPaths.CONFIGDIR.get().resolve(DebugGuardian.MOD_ID + "-common.toml").toString())
                     .inheritIO()
                     .start();
             DebugGuardian.LOGGER.info("Debug helper process launched");


### PR DESCRIPTION
## Summary
- Pass config file path to debug helper and load AI key before analyzing logs
- Use supplied API key when constructing AI log analyzer

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68c5a68c13108328886e415cd1bf6878