### PR TITLE
Fallback to basic log analysis when AI service returns no content

### DIFF
--- a/src/main/java/com/thunder/debugguardian/debug/external/AiLogAnalyzer.java
+++ b/src/main/java/com/thunder/debugguardian/debug/external/AiLogAnalyzer.java
@@ -83,8 +83,10 @@ public class AiLogAnalyzer implements LogAnalyzer {
 
             String response = readAll(responseStream);
             String content = extractContent(response);
-            return (content == null || content.isBlank())
-                    ? "AI service returned empty response." : content;
+            if (content == null || content.isBlank()) {
+                return fallback.analyze(threads);
+            }
+            return content;
         } catch (IOException e) {
             return "Failed to contact AI service: " + e.getMessage();
         }


### PR DESCRIPTION
## Summary
- avoid unhelpful "AI service returned empty response" by falling back to `BasicLogAnalyzer`

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c5d47c5aa88328948538f4d93fb246