### PR TITLE
Add memory leak monitor to debug system

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Completions API. It first reads the API key from the `logging.aiServiceApiKey`
 config entry, then falls back to `DEBUG_GUARDIAN_AI_KEY`. If neither is
 supplied it invokes the heuristic analyzer instead.
 
+Runtime monitors like `GcPauseMonitor`, `WorldHangDetector`, and the new
+`MemoryLeakMonitor` provide proactive warnings about server health, catching
+issues such as long GC pauses, hung ticks, or sustained high heap usage.
+
 Mapping Names:
 ============
 By default, the MDK is configured to use the official mapping names from Mojang for methods and fields 

--- a/src/main/java/com/thunder/debugguardian/DebugGuardian.java
+++ b/src/main/java/com/thunder/debugguardian/DebugGuardian.java
@@ -10,6 +10,7 @@ import com.thunder.debugguardian.debug.monitor.StartupFailureReporter;
 import com.thunder.debugguardian.debug.monitor.ThreadUsageMonitor;
 import com.thunder.debugguardian.debug.monitor.WorldGenFreezeDetector;
 import com.thunder.debugguardian.debug.monitor.WorldHangDetector;
+import com.thunder.debugguardian.debug.monitor.MemoryLeakMonitor;
 import com.thunder.debugguardian.debug.replay.PostMortemRecorder;
 import com.thunder.debugguardian.util.UnusedConfigScanner;
 import net.neoforged.bus.api.IEventBus;
@@ -68,6 +69,7 @@ public class DebugGuardian {
         GcPauseMonitor.start();
         WorldHangDetector.start();
         ForceCloseDetector.start();
+        MemoryLeakMonitor.start();
 
     }
 

--- a/src/main/java/com/thunder/debugguardian/debug/monitor/MemoryLeakMonitor.java
+++ b/src/main/java/com/thunder/debugguardian/debug/monitor/MemoryLeakMonitor.java
@@ -1,0 +1,49 @@
+package com.thunder.debugguardian.debug.monitor;
+
+import com.thunder.debugguardian.DebugGuardian;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Watches heap usage and warns when memory remains
+ * consistently high, hinting at a potential leak.
+ */
+public class MemoryLeakMonitor {
+    private static final double WARN_RATIO = 0.9; // 90% heap usage
+    private static final int WARN_STREAK = 3;     // checks before warning
+    private static int highUsageStreak = 0;
+
+    public static void start() {
+        Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(
+                MemoryLeakMonitor::checkMemory, 30, 30, TimeUnit.SECONDS);
+    }
+
+    private static void checkMemory() {
+        MemoryMXBean mem = ManagementFactory.getMemoryMXBean();
+        long used = mem.getHeapMemoryUsage().getUsed();
+        long max = mem.getHeapMemoryUsage().getMax();
+        double ratio = (double) used / max;
+
+        if (ratio > WARN_RATIO) {
+            highUsageStreak++;
+            if (highUsageStreak >= WARN_STREAK) {
+                DebugGuardian.LOGGER.warn(
+                        "Possible memory leak: heap usage at {}% for {} checks",
+                        Math.round(ratio * 100), highUsageStreak
+                );
+            }
+        } else {
+            if (highUsageStreak > 0) {
+                DebugGuardian.LOGGER.info(
+                        "Heap usage recovered after {} high-usage checks",
+                        highUsageStreak
+                );
+            }
+            highUsageStreak = 0;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add MemoryLeakMonitor to track sustained high heap usage
- start memory leak monitor during common setup
- document new monitor in README

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68c814347bcc8328817569bac21c5fb9