### PR TITLE
Fix helper reading partial force-close dumps

### DIFF
--- a/src/main/java/com/thunder/debugguardian/debug/external/BasicLogAnalyzer.java
+++ b/src/main/java/com/thunder/debugguardian/debug/external/BasicLogAnalyzer.java
@@ -47,7 +47,8 @@ public class BasicLogAnalyzer implements LogAnalyzer {
     @Override
     public String analyze(List<ThreadReport> threads) {
         if (threads.isEmpty()) {
-            return "No thread information available.";
+            return "No thread data was parsed from the force-close dump. "
+                    + "The log may have been empty or still being written when it was read.";
         }
 
         List<ThreadInsight> insights = threads.stream()


### PR DESCRIPTION
## Summary
- wait for force-close logs to finish writing before parsing them
- add fallback messaging when no thread data is parsed so summary and suspects files are informative
- clarify the heuristic analyzer message shown when no thread data is available

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_e_68c9c10ef110832890d90d6c0d2e690d