### PR TITLE
Improve world check heuristics and reporting

### DIFF
--- a/src/main/java/com/thunder/debugguardian/debug/command/WorldCheckCommand.java
+++ b/src/main/java/com/thunder/debugguardian/debug/command/WorldCheckCommand.java
@@ -108,18 +108,34 @@ public final class WorldCheckCommand {
             String summary = defaultStatus;
             try {
                 List<String> lines = Files.readAllLines(reportFile);
+                String statusText = null;
+                String summaryCounts = null;
+                String firstDetail = null;
                 for (String line : lines) {
-                    if (line.startsWith("Status:")) {
-                        summary = line.substring("Status:".length()).trim();
+                    if (statusText == null && line.startsWith("Status:")) {
+                        statusText = line.substring("Status:".length()).trim();
+                    } else if (summaryCounts == null && line.startsWith("Summary:")) {
+                        summaryCounts = line.substring("Summary:".length()).trim();
+                    } else if (firstDetail == null && line.startsWith(" - ")) {
+                        firstDetail = line.substring(3).trim();
+                    }
+
+                    if (statusText != null && summaryCounts != null && firstDetail != null) {
                         break;
                     }
                 }
-                for (String line : lines) {
-                    if (line.startsWith(" - ")) {
-                        summary = summary + " (" + line.substring(3) + ")";
-                        break;
-                    }
+
+                StringBuilder builder = new StringBuilder(summary);
+                if (statusText != null && !statusText.isEmpty()) {
+                    builder.append(" (Status: ").append(statusText).append(")");
                 }
+                if (summaryCounts != null && !summaryCounts.isEmpty()) {
+                    builder.append(" (").append(summaryCounts).append(")");
+                }
+                if (firstDetail != null && !firstDetail.isEmpty()) {
+                    builder.append(" (").append(firstDetail).append(")");
+                }
+                summary = builder.toString();
             } catch (IOException e) {
                 DebugGuardian.LOGGER.warn("Failed to read world check report", e);
             }

--- a/src/main/java/com/thunder/debugguardian/debug/external/WorldCheckHelper.java
+++ b/src/main/java/com/thunder/debugguardian/debug/external/WorldCheckHelper.java
@@ -1,15 +1,21 @@
 package com.thunder.debugguardian.debug.external;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.StandardOpenOption;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.ZipException;
 
 /**
  * Helper application launched by the /worldcheck command. It performs a series
@@ -47,6 +53,7 @@ public final class WorldCheckHelper {
         report.add("Generated: " + FORMAT.format(LocalDateTime.now()));
         report.add("World: " + worldDir.toAbsolutePath());
         report.add("Status: " + status);
+        report.add("Summary: " + errors.size() + " critical, " + warnings.size() + " warnings");
         report.add("");
 
         if (!errors.isEmpty()) {
@@ -89,9 +96,17 @@ public final class WorldCheckHelper {
     }
 
     private static void inspectWorld(Path worldDir, List<String> warnings, List<String> errors) {
-        checkFile(worldDir.resolve("level.dat"), "level.dat", true, warnings, errors);
-        checkFile(worldDir.resolve("session.lock"), "session.lock", false, warnings, errors);
-        checkFile(worldDir.resolve("level.dat_old"), "level.dat_old", false, warnings, errors);
+        Path levelDat = worldDir.resolve("level.dat");
+        Path sessionLock = worldDir.resolve("session.lock");
+        Path levelDatOld = worldDir.resolve("level.dat_old");
+
+        checkFile(levelDat, "level.dat", true, warnings, errors);
+        validateCompressedNbt(levelDat, "level.dat", true, warnings, errors);
+
+        checkFile(sessionLock, "session.lock", false, warnings, errors);
+
+        checkFile(levelDatOld, "level.dat_old", false, warnings, errors);
+        validateCompressedNbt(levelDatOld, "level.dat_old", false, warnings, errors);
 
         checkRegionDirectory(worldDir.resolve("region"), "Overworld", warnings, errors);
         checkRegionDirectory(worldDir.resolve("DIM-1").resolve("region"), "The Nether", warnings, errors);
@@ -172,20 +187,26 @@ public final class WorldCheckHelper {
     }
 
     private static void inspectRegionFile(Path file, String label, List<String> warnings, List<String> errors) {
+        long size;
         try {
-            long size = Files.size(file);
-            if (size == 0L) {
-                errors.add(label + " region file " + file.getFileName() + " is empty");
-            } else if (size < 16 * 1024L) {
-                warnings.add(label + " region file " + file.getFileName() + " is unusually small (" + size + " bytes)");
-            }
-
-            if (size % 4096L != 0L) {
-                warnings.add(label + " region file " + file.getFileName() + " size is not aligned to 4KiB (" + size + " bytes)");
-            }
+            size = Files.size(file);
         } catch (IOException e) {
             warnings.add("Failed to read region file " + file.getFileName() + " for " + label + ": " + e.getMessage());
+            return;
         }
+
+        if (size == 0L) {
+            errors.add(label + " region file " + file.getFileName() + " is empty");
+            return;
+        } else if (size < 16 * 1024L) {
+            warnings.add(label + " region file " + file.getFileName() + " is unusually small (" + size + " bytes)");
+        }
+
+        if (size % 4096L != 0L) {
+            warnings.add(label + " region file " + file.getFileName() + " size is not aligned to 4KiB (" + size + " bytes)");
+        }
+
+        validateRegionHeader(file, label, size, warnings, errors);
     }
 
     private static void inspectCustomDimensions(Path dimensionsDir, List<String> warnings, List<String> errors) {
@@ -270,6 +291,106 @@ public final class WorldCheckHelper {
             }
         } catch (IOException e) {
             warnings.add("Failed to inspect POI directory for " + label + ": " + e.getMessage());
+        }
+    }
+
+    private static void validateCompressedNbt(Path file, String description, boolean critical, List<String> warnings, List<String> errors) {
+        if (Files.notExists(file)) {
+            return;
+        }
+
+        try (InputStream input = Files.newInputStream(file); GZIPInputStream gzip = new GZIPInputStream(input)) {
+            byte[] buffer = new byte[8192];
+            boolean hasData = false;
+            while (gzip.read(buffer) != -1) {
+                hasData = true;
+            }
+            if (!hasData) {
+                String message = description + " decompressed to zero bytes, file may be truncated";
+                if (critical) {
+                    errors.add(message);
+                } else {
+                    warnings.add(message);
+                }
+            }
+        } catch (ZipException e) {
+            String message = description + " is not a valid compressed NBT file: " + e.getMessage();
+            if (critical) {
+                errors.add(message);
+            } else {
+                warnings.add(message);
+            }
+        } catch (IOException e) {
+            String message = "Failed to read " + description + " for integrity check: " + e.getMessage();
+            if (critical) {
+                errors.add(message);
+            } else {
+                warnings.add(message);
+            }
+        }
+    }
+
+    private static void validateRegionHeader(Path file, String label, long size, List<String> warnings, List<String> errors) {
+        if (size < 8192L) {
+            errors.add(label + " region file " + file.getFileName() + " is too small to contain a valid header (" + size + " bytes)");
+            return;
+        }
+
+        try (SeekableByteChannel channel = Files.newByteChannel(file, StandardOpenOption.READ)) {
+            ByteBuffer header = ByteBuffer.allocate(4096);
+            int read = channel.read(header);
+            if (read < 4096) {
+                errors.add(label + " region file " + file.getFileName() + " header is truncated (" + read + " bytes read)");
+                return;
+            }
+
+            header.flip();
+            long totalSectors = size / 4096L;
+            boolean hasChunkEntries = false;
+            boolean invalidOffsets = false;
+            boolean invalidSizes = false;
+            boolean zeroLengthChunks = false;
+
+            while (header.remaining() >= 4) {
+                int entry = header.getInt();
+                int offset = (entry >>> 8) & 0xFFFFFF;
+                int sectors = entry & 0xFF;
+
+                if (offset == 0 && sectors == 0) {
+                    continue;
+                }
+
+                if (sectors == 0) {
+                    zeroLengthChunks = true;
+                    continue;
+                }
+
+                hasChunkEntries = true;
+
+                if (offset < 2) {
+                    invalidOffsets = true;
+                }
+
+                long chunkEnd = (long) offset + sectors;
+                if (chunkEnd > totalSectors) {
+                    invalidSizes = true;
+                }
+            }
+
+            if (!hasChunkEntries) {
+                warnings.add(label + " region file " + file.getFileName() + " header lists no chunks; file may be empty or truncated");
+            }
+            if (invalidOffsets) {
+                errors.add(label + " region file " + file.getFileName() + " has chunk entries with invalid sector offsets");
+            }
+            if (invalidSizes) {
+                errors.add(label + " region file " + file.getFileName() + " has chunk entries that extend beyond the file size");
+            }
+            if (zeroLengthChunks) {
+                warnings.add(label + " region file " + file.getFileName() + " has chunk entries with zero length; file may be mid-write or corrupted");
+            }
+        } catch (IOException e) {
+            warnings.add("Failed to read region header for " + label + " file " + file.getFileName() + ": " + e.getMessage());
         }
     }
 }


### PR DESCRIPTION
## Summary
- add compressed NBT validation for level.dat files, validate region file headers, and include issue counts in the generated world check report
- enrich the /worldcheck command feedback with status codes, counts, and the first detected problem from the report

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68c9c342355083288678ff52824cc6e8