### PR TITLE
Fix duplicate report list declaration in WorldCheckHelper

### DIFF
--- a/src/main/java/com/thunder/debugguardian/debug/external/WorldCheckHelper.java
+++ b/src/main/java/com/thunder/debugguardian/debug/external/WorldCheckHelper.java
@@ -38,7 +38,6 @@ public final class WorldCheckHelper {
         Path reportFile = Paths.get(args[1]);
 
         WorldInspectionResult result = WorldIntegrityScanner.scan(worldDir);
-        List<String> report = result.buildReportLines(LocalDateTime.now(), FORMAT);
         List<String> errors = new ArrayList<>();
         List<String> warnings = new ArrayList<>();
         InspectionState inspectionState = new InspectionState();


### PR DESCRIPTION
## Summary
- remove the redundant report list declaration in `WorldCheckHelper` to resolve compilation failure

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68caf5d37764832892fb082e3aced4ce