### PR TITLE
Harden monitors and expose tuning knobs

### DIFF
--- a/src/main/java/com/thunder/debugguardian/DebugGuardian.java
+++ b/src/main/java/com/thunder/debugguardian/DebugGuardian.java
@@ -23,6 +23,8 @@ import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.server.ServerStartingEvent;
 import net.neoforged.neoforge.event.server.ServerStoppingEvent;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.fml.loading.FMLEnvironment;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -63,7 +65,9 @@ public class DebugGuardian {
 
     private void commonSetup(final FMLCommonSetupEvent event) {
         CrashRiskMonitor.start();
-        LiveLogMonitor.start();
+        if (FMLEnvironment.dist == Dist.CLIENT) {
+            LiveLogMonitor.start();
+        }
         PerformanceMonitor.init();
         PostMortemRecorder.init();
         WorldGenFreezeDetector.start();
@@ -78,12 +82,22 @@ public class DebugGuardian {
     @SubscribeEvent
     public void onServerStarting(ServerStartingEvent event) {
         UnusedConfigScanner.scanForUnusedConfigs(event.getServer());
+        MemoryLeakMonitor.start();
+        GcPauseMonitor.start();
+        if (FMLEnvironment.dist == Dist.CLIENT) {
+            PerformanceMonitor.init();
+        }
     }
 
     @SubscribeEvent
     public void onServerStopping(ServerStoppingEvent event) {
         Watchdog.stop();
         CrashRiskMonitor.stop();
+        MemoryLeakMonitor.stop();
+        GcPauseMonitor.stop();
+        if (FMLEnvironment.dist == Dist.CLIENT) {
+            PerformanceMonitor.shutdown();
+        }
     }
 }
 

--- a/src/main/java/com/thunder/debugguardian/config/DebugConfig.java
+++ b/src/main/java/com/thunder/debugguardian/config/DebugConfig.java
@@ -30,6 +30,41 @@ public class DebugConfig {
             .comment("Heap usage ratio (0.0 - 1.0) to trigger memory warning")
             .defineInRange("performance.memoryWarningRatio", 0.8D, 0.0D, 1.0D);
 
+    // Memory Leak Monitor Settings
+    public static final ModConfigSpec.DoubleValue MEMORY_LEAK_WARN_RATIO = BUILDER
+            .comment("Heap usage ratio (0.0 - 1.0) that increments the leak streak")
+            .defineInRange("monitoring.memoryLeak.warnRatio", 0.9D, 0.0D, 1.0D);
+
+    public static final ModConfigSpec.IntValue MEMORY_LEAK_WARN_STREAK = BUILDER
+            .comment("Number of consecutive checks over the ratio before warning")
+            .defineInRange("monitoring.memoryLeak.warnStreak", 3, 1, 100);
+
+    public static final ModConfigSpec.IntValue MEMORY_LEAK_CHECK_INTERVAL = BUILDER
+            .comment("Seconds between heap usage checks for the leak monitor")
+            .defineInRange("monitoring.memoryLeak.checkIntervalSeconds", 30, 5, 600);
+
+    // GC Pause Monitor Settings
+    public static final ModConfigSpec.LongValue GC_PAUSE_WARN_MS = BUILDER
+            .comment("GC pause duration (ms) considered suspicious")
+            .defineInRange("monitoring.gc.pauseWarnMs", 2_000L, 100L, 60_000L);
+
+    public static final ModConfigSpec.IntValue GC_PAUSE_CHECK_INTERVAL = BUILDER
+            .comment("Seconds between GC pause measurements")
+            .defineInRange("monitoring.gc.checkIntervalSeconds", 10, 1, 600);
+
+    // Watchdog Settings
+    public static final ModConfigSpec.LongValue WATCHDOG_MEMORY_CAP_MB = BUILDER
+            .comment("Heap usage (in MB) that triggers a watchdog warning")
+            .defineInRange("monitoring.watchdog.maxMemoryMb", 8_000L, 512L, 65_536L);
+
+    public static final ModConfigSpec.IntValue WATCHDOG_THREAD_CAP = BUILDER
+            .comment("Thread count that triggers a watchdog warning")
+            .defineInRange("monitoring.watchdog.maxThreads", 300, 32, 10_000);
+
+    public static final ModConfigSpec.IntValue WATCHDOG_CHECK_INTERVAL = BUILDER
+            .comment("Seconds between watchdog resource checks")
+            .defineInRange("monitoring.watchdog.checkIntervalSeconds", 10, 1, 600);
+
     // Compatibility Scanner Settings
     public static final ModConfigSpec.BooleanValue COMPAT_ENABLE_SCAN = BUILDER
             .comment("Enable scanning for known mod incompatibilities at startup")
@@ -81,6 +116,14 @@ public class DebugConfig {
     public final String reportingGithubRepository;
     public final long performanceTickThresholdMs;
     public final double performanceMemoryWarningRatio;
+    public final double memoryLeakWarnRatio;
+    public final int memoryLeakWarnStreak;
+    public final int memoryLeakCheckIntervalSeconds;
+    public final long gcPauseWarnMs;
+    public final int gcPauseCheckIntervalSeconds;
+    public final long watchdogMemoryCapMb;
+    public final int watchdogThreadCap;
+    public final int watchdogCheckIntervalSeconds;
     public final boolean compatibilityEnableScan;
     public final boolean loggingEnableLiveMonitor;
     public final String loggingAiServiceApiKey;
@@ -96,6 +139,14 @@ public class DebugConfig {
         this.reportingGithubRepository = REPORTING_GITHUB_REPO.get();
         this.performanceTickThresholdMs = PERFORMANCE_TICK_THRESHOLD.get();
         this.performanceMemoryWarningRatio = PERFORMANCE_MEMORY_RATIO.get();
+        this.memoryLeakWarnRatio = MEMORY_LEAK_WARN_RATIO.get();
+        this.memoryLeakWarnStreak = MEMORY_LEAK_WARN_STREAK.get();
+        this.memoryLeakCheckIntervalSeconds = MEMORY_LEAK_CHECK_INTERVAL.get();
+        this.gcPauseWarnMs = GC_PAUSE_WARN_MS.get();
+        this.gcPauseCheckIntervalSeconds = GC_PAUSE_CHECK_INTERVAL.get();
+        this.watchdogMemoryCapMb = WATCHDOG_MEMORY_CAP_MB.get();
+        this.watchdogThreadCap = WATCHDOG_THREAD_CAP.get();
+        this.watchdogCheckIntervalSeconds = WATCHDOG_CHECK_INTERVAL.get();
         this.compatibilityEnableScan = COMPAT_ENABLE_SCAN.get();
         this.loggingEnableLiveMonitor = LOGGING_ENABLE_LIVE.get();
         this.loggingAiServiceApiKey = LOGGING_AI_SERVICE_API_KEY.get();

--- a/src/main/java/com/thunder/debugguardian/debug/monitor/MemoryLeakMonitor.java
+++ b/src/main/java/com/thunder/debugguardian/debug/monitor/MemoryLeakMonitor.java
@@ -1,10 +1,12 @@
 package com.thunder.debugguardian.debug.monitor;
 
 import com.thunder.debugguardian.DebugGuardian;
+import com.thunder.debugguardian.config.DebugConfig;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -12,13 +14,29 @@ import java.util.concurrent.TimeUnit;
  * consistently high, hinting at a potential leak.
  */
 public class MemoryLeakMonitor {
-    private static final double WARN_RATIO = 0.9; // 90% heap usage
-    private static final int WARN_STREAK = 3;     // checks before warning
+    private static final String THREAD_NAME = "debugguardian-memory-leak";
     private static int highUsageStreak = 0;
+    private static ScheduledExecutorService scheduler;
 
-    public static void start() {
-        Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(
-                MemoryLeakMonitor::checkMemory, 30, 30, TimeUnit.SECONDS);
+    public static synchronized void start() {
+        if (scheduler != null && !scheduler.isShutdown()) {
+            return;
+        }
+        int interval = Math.max(1, DebugConfig.get().memoryLeakCheckIntervalSeconds);
+        scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, THREAD_NAME);
+            t.setDaemon(true);
+            return t;
+        });
+        scheduler.scheduleAtFixedRate(MemoryLeakMonitor::checkMemory, interval, interval, TimeUnit.SECONDS);
+    }
+
+    public static synchronized void stop() {
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+            scheduler = null;
+        }
+        highUsageStreak = 0;
     }
 
     private static void checkMemory() {
@@ -26,18 +44,24 @@ public class MemoryLeakMonitor {
         long used = mem.getHeapMemoryUsage().getUsed();
         long max = mem.getHeapMemoryUsage().getMax();
         double ratio = (double) used / max;
+        DebugConfig config = DebugConfig.get();
+        double warnRatio = config.memoryLeakWarnRatio;
+        int warnStreak = Math.max(1, config.memoryLeakWarnStreak);
 
-        if (ratio > WARN_RATIO) {
+        if (ratio > warnRatio) {
             highUsageStreak++;
-            if (highUsageStreak >= WARN_STREAK) {
+            if (highUsageStreak >= warnStreak) {
                 DebugGuardian.LOGGER.warn(
-                        "Possible memory leak: heap usage at {}% for {} checks",
-                        Math.round(ratio * 100), highUsageStreak
+                        "Possible memory leak: heap usage at {}% for {} checks (threshold {}% for {} checks)",
+                        Math.round(ratio * 100), highUsageStreak,
+                        Math.round(warnRatio * 100), warnStreak
                 );
                 CrashRiskMonitor.recordSymptom(
                         "memory-leak",
                         CrashRiskMonitor.Severity.HIGH,
-                        "Heap usage > " + Math.round(ratio * 100) + "% for " + highUsageStreak + " checks"
+                        "Heap usage > " + Math.round(ratio * 100) + "% for " + highUsageStreak
+                                + " checks (threshold " + Math.round(warnRatio * 100) + "% for "
+                                + warnStreak + " checks)"
                 );
             }
         } else {

--- a/src/main/java/com/thunder/debugguardian/debug/monitor/client/LogNotificationSender.java
+++ b/src/main/java/com/thunder/debugguardian/debug/monitor/client/LogNotificationSender.java
@@ -1,0 +1,33 @@
+package com.thunder.debugguardian.debug.monitor.client;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
+
+/**
+ * Client-side helpers for surfacing live log alerts to the player.
+ */
+public final class LogNotificationSender {
+    private LogNotificationSender() {
+    }
+
+    public static void notifyPlayer(String logLine, String advice, String reportUrl) {
+        Minecraft mc = Minecraft.getInstance();
+        if (mc.level == null || mc.player == null) {
+            return;
+        }
+        mc.execute(() -> {
+            mc.player.sendSystemMessage(
+                    Component.literal("§c[Debug Guardian] Detected: " + logLine));
+            mc.player.sendSystemMessage(Component.literal("§6" + advice));
+            mc.player.sendSystemMessage(
+                    Component.literal("§9[Report issue]")
+                            .withStyle(style -> style
+                                    .withClickEvent(new ClickEvent(
+                                            ClickEvent.Action.OPEN_URL, reportUrl))
+                                    .withUnderlined(true)
+                            )
+            );
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- guard the live log monitor behind the client dist and move chat notifications into a client-only helper
- add configuration entries for GC, leak, and watchdog thresholds and update the associated monitors to honour them
- ensure background schedulers use daemon threads, keep references, and stop/restart cleanly alongside the server lifecycle

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68cc1ef55c908328b350a0a7e70ad47b