### PR TITLE
Fix config initialization race and reschedule monitors

### DIFF
--- a/src/main/java/com/thunder/debugguardian/DebugGuardian.java
+++ b/src/main/java/com/thunder/debugguardian/DebugGuardian.java
@@ -57,7 +57,6 @@ public class DebugGuardian {
 
         container.registerConfig(ModConfig.Type.COMMON, DebugConfig.SPEC);
 
-        Watchdog.start();
         StartupFailureReporter.install();
 
 
@@ -82,6 +81,7 @@ public class DebugGuardian {
     @SubscribeEvent
     public void onServerStarting(ServerStartingEvent event) {
         UnusedConfigScanner.scanForUnusedConfigs(event.getServer());
+        Watchdog.reloadFromConfig();
         MemoryLeakMonitor.start();
         GcPauseMonitor.start();
         if (FMLEnvironment.dist == Dist.CLIENT) {

--- a/src/main/java/com/thunder/debugguardian/debug/monitor/CrashRiskMonitor.java
+++ b/src/main/java/com/thunder/debugguardian/debug/monitor/CrashRiskMonitor.java
@@ -69,6 +69,14 @@ public final class CrashRiskMonitor {
         SYMPTOMS.clear();
     }
 
+    public static void reloadFromConfig() {
+        if (!DebugConfig.get().crashRiskEnable) {
+            stop();
+        } else {
+            start();
+        }
+    }
+
     /**
      * Records a suspicious signal. Each key represents a single signal source;
      * new data refreshes the timestamp and increases the occurrence count so

--- a/src/main/java/com/thunder/debugguardian/debug/monitor/MemoryLeakMonitor.java
+++ b/src/main/java/com/thunder/debugguardian/debug/monitor/MemoryLeakMonitor.java
@@ -7,6 +7,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -17,26 +18,53 @@ public class MemoryLeakMonitor {
     private static final String THREAD_NAME = "debugguardian-memory-leak";
     private static int highUsageStreak = 0;
     private static ScheduledExecutorService scheduler;
+    private static ScheduledFuture<?> scheduledTask;
 
     public static synchronized void start() {
-        if (scheduler != null && !scheduler.isShutdown()) {
+        ensureScheduler();
+        reschedule();
+    }
+
+    public static synchronized void reloadFromConfig() {
+        if (scheduler == null || scheduler.isShutdown()) {
             return;
         }
-        int interval = Math.max(1, DebugConfig.get().memoryLeakCheckIntervalSeconds);
-        scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
-            Thread t = new Thread(r, THREAD_NAME);
-            t.setDaemon(true);
-            return t;
-        });
-        scheduler.scheduleAtFixedRate(MemoryLeakMonitor::checkMemory, interval, interval, TimeUnit.SECONDS);
+        reschedule();
     }
 
     public static synchronized void stop() {
+        if (scheduledTask != null) {
+            scheduledTask.cancel(true);
+            scheduledTask = null;
+        }
         if (scheduler != null) {
             scheduler.shutdownNow();
             scheduler = null;
         }
         highUsageStreak = 0;
+    }
+
+    private static void ensureScheduler() {
+        if (scheduler == null || scheduler.isShutdown()) {
+            scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, THREAD_NAME);
+                t.setDaemon(true);
+                return t;
+            });
+        }
+    }
+
+    private static void reschedule() {
+        int interval = Math.max(1, DebugConfig.get().memoryLeakCheckIntervalSeconds);
+        if (scheduledTask != null && !scheduledTask.isCancelled()) {
+            scheduledTask.cancel(false);
+        }
+        scheduledTask = scheduler.scheduleAtFixedRate(
+                MemoryLeakMonitor::checkMemory,
+                interval,
+                interval,
+                TimeUnit.SECONDS
+        );
     }
 
     private static void checkMemory() {


### PR DESCRIPTION
## Summary
- provide a default DebugConfig snapshot until NeoForge loads the config file
- reschedule watchdog, memory leak, and GC pause monitors when config values change
- restart the watchdog on server start and teach the crash risk monitor to respect config reloads

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68cee7b681dc8328af408a1ea78762b1