### PR TITLE
Allow post-mortem recorder to reload configuration

### DIFF
--- a/src/main/java/com/thunder/debugguardian/config/DebugConfig.java
+++ b/src/main/java/com/thunder/debugguardian/config/DebugConfig.java
@@ -4,6 +4,7 @@ import com.thunder.debugguardian.debug.Watchdog;
 import com.thunder.debugguardian.debug.monitor.CrashRiskMonitor;
 import com.thunder.debugguardian.debug.monitor.GcPauseMonitor;
 import com.thunder.debugguardian.debug.monitor.MemoryLeakMonitor;
+import com.thunder.debugguardian.debug.replay.PostMortemRecorder;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.event.config.ModConfigEvent;
@@ -244,6 +245,7 @@ public class DebugConfig {
             MemoryLeakMonitor.reloadFromConfig();
             GcPauseMonitor.reloadFromConfig();
             CrashRiskMonitor.reloadFromConfig();
+            PostMortemRecorder.reloadFromConfig();
         }
     }
 }

--- a/src/main/java/com/thunder/debugguardian/debug/replay/PostMortemRecorder.java
+++ b/src/main/java/com/thunder/debugguardian/debug/replay/PostMortemRecorder.java
@@ -19,7 +19,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 public class PostMortemRecorder {
     private static PostMortemRecorder instance;
     private Deque<GameEvent> buffer;
-    private int capacity;
+    private volatile int capacity;
 
     private PostMortemRecorder() {
         // no-op; actual init in init()
@@ -31,7 +31,7 @@ public class PostMortemRecorder {
     public static void init() {
         if (instance == null) {
             instance = new PostMortemRecorder();
-            instance.capacity = DebugConfig.get().postmortemBufferSize;
+            instance.capacity = Math.max(1, DebugConfig.get().postmortemBufferSize);
             instance.buffer = new ConcurrentLinkedDeque<>();
         }
     }
@@ -47,7 +47,7 @@ public class PostMortemRecorder {
     /** Record a single game event onto the buffer. */
     public void record(GameEvent event) {
         buffer.addLast(event);
-        if (buffer.size() > capacity) buffer.removeFirst();
+        trimToCapacity();
     }
 
     @SubscribeEvent
@@ -61,6 +61,15 @@ public class PostMortemRecorder {
     }
 
     /**
+     * Reload recorder settings from the latest configuration.
+     */
+    public static void reloadFromConfig() {
+        PostMortemRecorder recorder = get();
+        recorder.capacity = Math.max(1, DebugConfig.get().postmortemBufferSize);
+        recorder.trimToCapacity();
+    }
+
+    /**
      * Dump the current buffer to a JSON file in the crash directory.
      */
     public void dump(Path crashDir) {
@@ -71,6 +80,12 @@ public class PostMortemRecorder {
             Files.writeString(out, json);
         } catch (IOException e) {
             DebugGuardian.LOGGER.error("Failed to dump post-mortem buffer", e);
+        }
+    }
+
+    private void trimToCapacity() {
+        while (buffer.size() > capacity) {
+            buffer.pollFirst();
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow the post-mortem recorder to update its buffer capacity when the config changes
- trim stored events to the new size and guard against invalid capacities
- invoke the recorder's reload hook from the mod config handler

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d293f61dd88328841930e2330e525a